### PR TITLE
make propName optional

### DIFF
--- a/build/annotations.d.ts
+++ b/build/annotations.d.ts
@@ -1,2 +1,2 @@
-export declare function InjectUser(propName: string): (cls: any) => any;
+export declare function InjectUser(propName?: string): (cls: any) => any;
 export declare const RequireUser: (...args: any[]) => (cls: any) => any;


### PR DESCRIPTION
When using like this `InjectUser()`, right now gets warning:

> Invalid numver of arguments, expected 1
