### PR TITLE
Fix early route check

### DIFF
--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -48,12 +48,21 @@ export function InjectUser(propName?: string): (cls: any) => any {
  * A service to use as auth guard on the route.
  *
  */
- export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate {
 
-     canActivate (){
-       return !!Meteor.user();
-
-   }
- }
-
-
+	canActivate():Observable<boolean> {
+		let subject = new Subject<boolean>();
+		/*
+ 		 * Wait until Meteor isn't actively logging in to
+		 * decide that we're logged in or not.
+		 */
+		Tracker.autorun((c) => {
+			if (!Meteor.loggingIn()) {
+				subject.next(!!Meteor.user());
+				subject.complete();
+				c.stop();
+			}
+		});
+		return subject.asObservable();
+	}
+}


### PR DESCRIPTION
If the user starts by loading a restricted route Angular 2 will call `canActivate` while Meteor is still verifying the current login.

We must wait until Meteor has finished the login procedure and actually have a valid user to be able to deliver a valid answer to the router.
