### PR TITLE
Build component to reset password

### DIFF
--- a/src/accounts-module.ts
+++ b/src/accounts-module.ts
@@ -2,22 +2,27 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {LoginButtons} from './login-buttons';
+import {ResetPassword} from './reset-password';
 import {AuthGuard} from "./annotations";
+import {accountsRouting} from "./routes";
+
 
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule
+    FormsModule,
+    accountsRouting
   ],
   declarations: [
-    LoginButtons
+    LoginButtons,
+    ResetPassword
   ],
   providers: [
     AuthGuard
   ],
   exports: [
-    LoginButtons
+    LoginButtons,
+    ResetPassword
   ]
 })
-export class AccountsModule {
-}
+export class AccountsModule {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './login-buttons';
+export * from './reset-password';
 export * from './annotations';
 export * from './accounts-module';

--- a/src/reset-password.ts
+++ b/src/reset-password.ts
@@ -1,0 +1,140 @@
+import { Component, OnInit, OnDestroy, NgZone } from '@angular/core';
+import { ActivatedRoute, Router } from "@angular/router";
+import { Subscription } from 'rxjs/Subscription';
+import { Accounts } from 'meteor/accounts-base'
+
+@Component({
+  selector: 'reset-password',
+  styles: [
+    `
+      .reset-password {
+        position: relative;
+        display: inline-block;
+      }
+
+      .reset-password .content-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        border: 1px solid #ccc;
+        z-index: 1000;
+        background: white;
+        border-radius: 4px;
+        padding: 8px 12px;
+        margin: -8px -12px 0 -12px;
+        width: 250px;
+        box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.2);
+        -webkit-box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.2);
+        font-size: 16px;
+        color: #333;
+        line-height: 1.6;
+      }
+
+      .reset-password .content-container label {
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 80%;
+        margin-top: 7px;
+        margin-bottom: -2px;
+        display: inline;
+      }
+
+      .reset-password .content-container input {
+        padding: 4px;
+        margin: 0px;
+        border: 1px solid #aaa;
+        line-height: 1;
+        box-sizing: border-box;
+        width: 100%;
+        height: auto;
+      }
+
+      .reset-password #reset-button {
+        width: 100%;
+        margin: 8px 0px 4px 0px;
+        cursor: pointer;
+        user-select: none;
+        padding: 4px 8px;
+        font-size: 80%;
+        line-height: 1.5;
+        text-align: center;
+        color: #fff;
+        background: #596595;
+        background-image: initial;
+        background-position-x: initial;
+        background-position-y: initial;
+        background-size: initial;
+        background-repeat-x: initial;
+        background-repeat-y: initial;
+        background-attachment: initial;
+        background-origin: initial;
+        background-clip: initial;
+        background-color: rgb(89, 101, 149);
+        border: 1px solid #464f75;
+        border-top-color: rgb(70, 79, 117);
+        border-top-style: solid;
+        border-top-width: 1px;
+        border-right-color: rgb(70, 79, 117);
+        border-right-style: solid;
+        border-right-width: 1px;
+        border-bottom-color: rgb(70, 79, 117);
+        border-bottom-style: solid;
+        border-bottom-width: 1px;
+        border-left-color: rgb(70, 79, 117);
+        border-left-style: solid;
+        border-left-width: 1px;
+        border-image-source: initial;
+        border-image-slice: initial;
+        border-image-width: initial;
+        border-image-outset: initial;
+        border-image-repeat: initial;
+        border-radius: 4px;
+      }`],
+  template: `
+    <div class="reset-password">
+      <div class="content-container">
+          <form class="reset-password-form">
+            <div>
+              <label for="password">New Password</label>
+              <input class="form-control" type="password" name="password" required [(ngModel)]="password"/>
+            </div>
+            <label [hidden]="!error">{{ error }}</label>
+            <button id="reset-button" (click)="resetPassword()" [disabled]="processing || !token">Set password</button>
+          </form>
+      </div>
+    </div>
+  `
+})
+export class ResetPassword implements OnInit, OnDestroy {
+  private error: string = "No token found";
+  private token: string;
+  private password: string;
+  private processing: boolean = false;
+  private routeSubscription: Subscription;
+
+  constructor(private route: ActivatedRoute, private router: Router, private zone: NgZone) { }
+
+  ngOnInit() {
+    this.routeSubscription = this.route.params.subscribe((params: any) => {
+      this.token = params.token;
+      if (this.token) { this.error = ""; };
+    });
+  }
+
+  ngOnDestroy() {
+    this.routeSubscription.unsubscribe();
+  }
+
+  private resetPassword(): void {
+    this.processing = true;
+    Accounts.resetPassword(this.token, this.password, (error) => {
+      this.zone.run(()=>{
+        this.processing = false;
+        if (error) {
+          this.error = error;
+        } else {
+          this.router.navigate(['/']);
+        }
+      });
+    });
+  }
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,10 @@
+import { Routes, RouterModule } from '@angular/router';
+
+import { ResetPassword } from "./reset-password";
+
+const accountsRoutes: Routes = [{
+  path: 'reset-password/:token',
+  component: ResetPassword
+}];
+
+export const accountsRouting = RouterModule.forRoot(accountsRoutes);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,8 @@
+import { Meteor } from 'meteor/meteor';
+import { Accounts } from 'meteor/accounts-base';
+
+if (Meteor.isServer) {
+  Accounts.emailTemplates.resetPassword.text = function(user, url) {
+    return `Hello,\n\nTo reset your password, simply click the link below.\n\n${url.replace("#/", "")}\n\nThanks.`;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
   },
   "files": [
     "typings.d.ts",
-    "src/index.ts"
+    "src/index.ts",
+    "src/server.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
New route `reset-password/:token` included in NgModule for password resets.

Since Meteor puts a # in the reset password URL to pop up a model, in the server you need to` import "angular2-meteor-accounts-ui/build/server";` to remove the # from the reset password url.

As of right now I haven't seen anyway to have password reset to work so I wrote this up.

Also I only "tested" this in an app, by linking to the `src` folder. I couldn't get the build to work... I didn't have access to the `typings.d.ts`, and tried to configure something but still got errors...  😫